### PR TITLE
Fix blank Procurement Intelligence page + add E2E test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,292 @@
+"""
+Shared fixtures for E2E tests.
+Uses FastAPI TestClient with SQLite in-memory DB and mocked external services.
+"""
+
+import os
+import sys
+import uuid
+
+# Set required env vars BEFORE any app imports (Settings is evaluated at import time)
+os.environ["CLAUDE_API_KEY"] = "test-key-for-e2e"
+os.environ["RECEIPTS_API_KEY"] = "test-receipts-key"
+os.environ["STRIPE_SECRET_KEY"] = "sk_test_fake_key_for_e2e"
+os.environ["STRIPE_PUBLISHABLE_KEY"] = "pk_test_fake_key_for_e2e"
+os.environ["STRIPE_WEBHOOK_SECRET"] = "whsec_test_fake_for_e2e"
+os.environ["DATABASE_URL"] = "sqlite://"
+os.environ["JWT_SECRET"] = "test-jwt-secret-e2e-1234567890"
+os.environ["SECRET_KEY"] = "test-secret-key-e2e"
+os.environ["DEBUG"] = "false"
+
+from unittest.mock import MagicMock
+import pytest
+import numpy as np
+import sqlalchemy as _sa
+from sqlalchemy import event
+from sqlalchemy.orm import sessionmaker
+
+# ── Monkey-patch create_engine to handle SQLite ──────────────────────────────
+# app.database.session calls create_engine() at module level with pool_size and
+# max_overflow, which SQLite does not support. We wrap it to strip those params.
+
+_original_create_engine = _sa.create_engine
+
+
+def _patched_create_engine(url, **kwargs):
+    if str(url).startswith("sqlite"):
+        kwargs.pop("pool_size", None)
+        kwargs.pop("max_overflow", None)
+        kwargs.pop("pool_pre_ping", None)
+        # Use StaticPool so all connections share the same in-memory DB
+        from sqlalchemy.pool import StaticPool
+        kwargs["poolclass"] = StaticPool
+        kwargs["connect_args"] = {"check_same_thread": False}
+    return _original_create_engine(url, **kwargs)
+
+
+_sa.create_engine = _patched_create_engine
+
+# Stub out heavy ML modules before any app import pulls them in
+_mock_faiss = MagicMock()
+_mock_faiss_index = MagicMock()
+_mock_faiss_index.ntotal = 0  # Empty index returns int, not MagicMock
+_mock_faiss.IndexFlatL2.return_value = _mock_faiss_index
+sys.modules["faiss"] = _mock_faiss
+sys.modules["sentence_transformers"] = MagicMock()
+
+# Patch embed_text early — the module will be imported by the app
+import app.nlp.embeddings as _emb_mod  # noqa: E402
+
+
+def _fake_embed_text(text):
+    np.random.seed(hash(text) % 2**32)
+    return np.random.rand(384).astype("float32")
+
+
+_emb_mod._get_model = MagicMock()
+_emb_mod.embed_text = _fake_embed_text
+_emb_mod.cosine_similarity = lambda a, b: float(
+    np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b))
+)
+
+# Now safe to import the app
+from app.database.session import Base, get_db, engine as app_engine  # noqa: E402
+from app.main import app  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
+
+# Restore original create_engine for any later usage
+_sa.create_engine = _original_create_engine
+
+
+# ── DB fixture setup ─────────────────────────────────────────────────────────
+
+@event.listens_for(app_engine, "connect")
+def _set_sqlite_pragma(dbapi_conn, connection_record):
+    cursor = dbapi_conn.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
+_TestSessionLocal = sessionmaker(bind=app_engine, autocommit=False, autoflush=False)
+
+
+def _override_get_db():
+    db = _TestSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = _override_get_db
+
+
+# ── Sample data ──────────────────────────────────────────────────────────────
+
+SAMPLE_CONTRACT = """
+MASTER SERVICES AGREEMENT
+
+This Master Services Agreement ("Agreement") is entered into as of January 1, 2025
+("Effective Date") by and between Acme Corp., a corporation organized under the
+laws of Ontario, Canada ("Client"), and TechVendor Inc., a corporation organized
+under the laws of British Columbia, Canada ("Service Provider").
+
+1. SERVICES
+The Service Provider agrees to provide software development and IT consulting
+services ("Services") as described in each Statement of Work ("SOW") executed
+pursuant to this Agreement. Each SOW shall specify the scope, deliverables,
+timeline, and fees for the particular engagement.
+
+2. TERM AND TERMINATION
+This Agreement shall commence on the Effective Date and continue for a period
+of two (2) years ("Initial Term"), unless earlier terminated. Either party may
+terminate this Agreement upon sixty (60) days written notice. In the event of a
+material breach, the non-breaching party may terminate upon thirty (30) days
+written notice if the breach remains uncured.
+
+3. FEES AND PAYMENT
+Client shall pay Service Provider the fees set forth in each SOW. Payment shall
+be due within thirty (30) days of receipt of invoice. Late payments shall accrue
+interest at the rate of 1.5% per month or the maximum rate permitted by law,
+whichever is less.
+
+4. CONFIDENTIALITY
+Each party agrees to maintain the confidentiality of all proprietary information
+disclosed by the other party during the term of this Agreement. Confidential
+information shall not include information that: (a) is or becomes publicly
+available; (b) was known to the receiving party prior to disclosure; (c) is
+independently developed by the receiving party; or (d) is disclosed pursuant
+to a court order.
+
+5. INTELLECTUAL PROPERTY
+All intellectual property developed by Service Provider specifically for Client
+under this Agreement ("Work Product") shall be the exclusive property of Client
+upon full payment. Service Provider retains ownership of all pre-existing
+intellectual property, tools, and methodologies.
+
+6. LIABILITY
+Neither party shall be liable for any indirect, incidental, special, or
+consequential damages arising out of this Agreement. The total aggregate liability
+of either party shall not exceed the fees paid or payable under this Agreement
+during the twelve (12) month period preceding the claim.
+
+7. GOVERNING LAW
+This Agreement shall be governed by and construed in accordance with the laws of
+the Province of Ontario and the federal laws of Canada applicable therein.
+
+IN WITNESS WHEREOF, the parties have executed this Agreement as of the Effective Date.
+"""
+
+SAMPLE_CLAUSE_TEXT = (
+    "The Contractor shall indemnify and hold harmless the Crown from and against "
+    "all claims, losses, damages, costs, expenses, and liabilities arising out of "
+    "or in connection with the performance or non-performance of the Work."
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_database():
+    """Create all tables once before tests, drop after."""
+    from app.models import user, clause, tender, audit  # noqa: F401
+    Base.metadata.create_all(bind=app_engine)
+    yield
+    Base.metadata.drop_all(bind=app_engine)
+
+
+@pytest.fixture(scope="session")
+def client():
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture(scope="session")
+def test_user_credentials():
+    uid = uuid.uuid4().hex[:8]
+    return {
+        "username": f"e2etest_{uid}",
+        "email": f"e2etest_{uid}@lexara-test.dev",
+        "password": "TestPass!2025secure",
+        "role": "procurement",
+    }
+
+
+@pytest.fixture(scope="session")
+def auth_token(client, test_user_credentials):
+    """Register a test user and return the JWT access token."""
+    resp = client.post("/v1/auth/register", json=test_user_credentials)
+    assert resp.status_code in (200, 400), f"Register: {resp.status_code} {resp.text}"
+
+    resp = client.post("/v1/auth/login", json={
+        "username": test_user_credentials["username"],
+        "password": test_user_credentials["password"],
+    })
+    assert resp.status_code == 200, f"Login failed: {resp.status_code} {resp.text}"
+    data = resp.json()
+    assert "access_token" in data
+    return data["access_token"]
+
+
+@pytest.fixture(scope="session")
+def auth_headers(auth_token):
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+# ── Mock Claude API responses ────────────────────────────────────────────────
+
+MOCK_SUMMARY_RESPONSE = {
+    "summary": "This is a standard Master Services Agreement between Acme Corp and TechVendor Inc for software development and IT consulting services under Ontario law.",
+    "contract_type": "service_agreement",
+    "jurisdiction": "ON",
+    "confidence": 0.92,
+    "tokens_used": 150,
+}
+
+MOCK_RISK_SCORE_RESPONSE = {
+    "overall_risk_score": 45,
+    "risk_level": "medium",
+    "scores_by_category": {
+        "liability": 50,
+        "data_protection": 60,
+        "termination": 30,
+        "ip_ownership": 40,
+        "warranty": 55,
+    },
+    "interpretation": "Moderate risk due to broad liability limitation and lack of data protection clause.",
+    "tokens_used": 180,
+}
+
+MOCK_KEY_RISKS_RESPONSE = {
+    "key_risks": [
+        {
+            "severity": "high",
+            "title": "Broad Liability Limitation",
+            "description": "The liability cap is broad and may not adequately protect either party.",
+            "section": "Section 6",
+            "recommendation": "Consider adding carve-outs for gross negligence and wilful misconduct.",
+        },
+        {
+            "severity": "medium",
+            "title": "No Data Protection Clause",
+            "description": "Agreement lacks provisions for handling personal data under PIPEDA.",
+            "section": None,
+            "recommendation": "Add a privacy and data protection schedule.",
+        },
+    ],
+    "tokens_used": 200,
+}
+
+MOCK_MISSING_CLAUSES_RESPONSE = {
+    "missing_clauses": [
+        {
+            "clause": "Force Majeure",
+            "importance": "high",
+            "rationale": "No provision for unforeseeable events that could prevent performance.",
+        },
+        {
+            "clause": "Dispute Resolution",
+            "importance": "medium",
+            "rationale": "No alternative dispute resolution mechanism before litigation.",
+        },
+    ],
+    "tokens_used": 160,
+}
+
+MOCK_EXTRACT_CLAUSES_RESPONSE = {
+    "clauses": [
+        {
+            "type": "termination",
+            "section": "Section 2",
+            "summary": "Either party may terminate with 60 days notice or 30 days for material breach.",
+            "confidence": 0.95,
+        },
+        {
+            "type": "liability",
+            "section": "Section 6",
+            "summary": "Excludes indirect damages and caps aggregate liability at 12 months of fees.",
+            "confidence": 0.93,
+        },
+    ],
+    "tokens_used": 170,
+}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,561 @@
+"""
+End-to-end tests for LexAra API.
+
+Runs against the FastAPI app using TestClient with SQLite and mocked external
+services. Covers: health, auth, contract analysis (5 tabs), upload, billing/plans,
+usage, procurement tools (lint, citations, clauses), and error handling.
+"""
+
+import io
+from unittest.mock import patch, AsyncMock, MagicMock
+import pytest
+
+from tests.conftest import (
+    SAMPLE_CONTRACT,
+    SAMPLE_CLAUSE_TEXT,
+    MOCK_SUMMARY_RESPONSE,
+    MOCK_RISK_SCORE_RESPONSE,
+    MOCK_KEY_RISKS_RESPONSE,
+    MOCK_MISSING_CLAUSES_RESPONSE,
+    MOCK_EXTRACT_CLAUSES_RESPONSE,
+)
+
+
+# ─── 1. Public / Health Endpoints ────────────────────────────────────────────
+
+
+class TestHealthEndpoints:
+
+    def test_root(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "message" in data
+        assert "api_version" in data
+
+    def test_health(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert "timestamp" in data
+        assert "version" in data
+
+    def test_openapi_docs(self, client):
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        assert "paths" in schema
+        assert "info" in schema
+
+
+# ─── 2. Authentication Flow ─────────────────────────────────────────────────
+
+
+class TestAuthFlow:
+
+    def test_register_new_user(self, client, test_user_credentials):
+        resp = client.post("/v1/auth/register", json=test_user_credentials)
+        # May already be registered by the auth_token fixture
+        assert resp.status_code in (200, 400)
+        if resp.status_code == 200:
+            data = resp.json()
+            assert data["username"] == test_user_credentials["username"]
+
+    def test_register_duplicate_user(self, client, test_user_credentials):
+        # Ensure user exists
+        client.post("/v1/auth/register", json=test_user_credentials)
+        resp = client.post("/v1/auth/register", json=test_user_credentials)
+        assert resp.status_code == 400
+        assert "already taken" in resp.json().get("detail", "").lower()
+
+    def test_login_valid(self, client, test_user_credentials):
+        resp = client.post("/v1/auth/login", json={
+            "username": test_user_credentials["username"],
+            "password": test_user_credentials["password"],
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+        assert "role" in data
+
+    def test_login_wrong_password(self, client, test_user_credentials):
+        resp = client.post("/v1/auth/login", json={
+            "username": test_user_credentials["username"],
+            "password": "WrongPassword123!",
+        })
+        assert resp.status_code == 401
+
+    def test_login_nonexistent_user(self, client):
+        resp = client.post("/v1/auth/login", json={
+            "username": "nonexistent_user_xyz_999",
+            "password": "anything",
+        })
+        assert resp.status_code == 401
+
+
+# ─── 3. Auth Enforcement ────────────────────────────────────────────────────
+
+
+class TestAuthEnforcement:
+
+    @pytest.mark.parametrize("method,path", [
+        ("GET", "/v1/plans"),
+        ("GET", "/v1/usage"),
+        ("POST", "/v1/summary"),
+        ("POST", "/v1/risk-score"),
+        ("POST", "/v1/key-risks"),
+        ("POST", "/v1/missing-clauses"),
+        ("POST", "/v1/extract-clauses"),
+        ("POST", "/v1/upload"),
+        ("POST", "/v1/procurement/lint"),
+        ("POST", "/v1/procurement/citations"),
+        ("POST", "/v1/procurement/clauses"),
+    ])
+    def test_no_auth_returns_401(self, client, method, path):
+        if method == "GET":
+            resp = client.get(path)
+        else:
+            resp = client.post(path, json={"text": "test"})
+        assert resp.status_code == 401, f"{method} {path} returned {resp.status_code}"
+
+
+# ─── 4. Billing / Plans ─────────────────────────────────────────────────────
+
+
+class TestBillingPlans:
+
+    def test_list_plans(self, client, auth_headers):
+        resp = client.get("/v1/plans", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plans" in data
+        plans = data["plans"]
+        assert "free" in plans
+        assert "starter" in plans
+        assert "growth" in plans
+        assert "business" in plans
+        assert plans["free"]["price_cad"] == 0
+        assert plans["business"]["analyses_limit"] == -1
+
+    def test_checkout_free_plan_rejected(self, client, auth_headers):
+        resp = client.post("/v1/checkout", headers=auth_headers, json={
+            "plan_id": "free",
+            "email": "test@example.com",
+        })
+        assert resp.status_code == 400
+        assert "free" in resp.json().get("detail", "").lower()
+
+    def test_checkout_invalid_plan(self, client, auth_headers):
+        resp = client.post("/v1/checkout", headers=auth_headers, json={
+            "plan_id": "nonexistent_plan",
+            "email": "test@example.com",
+        })
+        assert resp.status_code == 400
+
+
+# ─── 5. Usage ────────────────────────────────────────────────────────────────
+
+
+class TestUsage:
+
+    def test_get_usage(self, client, auth_headers):
+        resp = client.get("/v1/usage", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plan" in data
+        assert "analyses_used_this_month" in data
+        assert "analyses_limit" in data
+        assert "remaining_quota" in data
+
+
+# ─── 6. Contract Analysis (5 Tabs) — with mocked Claude API ─────────────────
+
+
+class TestContractAnalysis:
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_summary(self, mock_claude, client, auth_headers):
+        mock_claude.return_value = MOCK_SUMMARY_RESPONSE
+        resp = client.post("/v1/summary", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "services",
+            "jurisdiction": "ON",
+        })
+        assert resp.status_code == 200, f"Summary failed: {resp.text}"
+        data = resp.json()
+        assert "analysis_id" in data
+        assert len(data["summary"]) > 0
+        assert "contract_type" in data
+        assert "confidence" in data
+        assert data["processing_time_ms"] >= 0
+        mock_claude.assert_called_once()
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_risk_score(self, mock_claude, client, auth_headers):
+        mock_claude.return_value = MOCK_RISK_SCORE_RESPONSE
+        resp = client.post("/v1/risk-score", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "services",
+            "jurisdiction": "ON",
+        })
+        assert resp.status_code == 200, f"Risk score failed: {resp.text}"
+        data = resp.json()
+        assert "analysis_id" in data
+        assert 0 <= data["overall_risk_score"] <= 100
+        assert data["risk_level"] in ("low", "medium", "high", "critical")
+        assert "scores_by_category" in data
+        assert "interpretation" in data
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_key_risks(self, mock_claude, client, auth_headers):
+        mock_claude.return_value = MOCK_KEY_RISKS_RESPONSE
+        resp = client.post("/v1/key-risks", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "services",
+            "jurisdiction": "ON",
+        })
+        assert resp.status_code == 200, f"Key risks failed: {resp.text}"
+        data = resp.json()
+        assert "analysis_id" in data
+        assert isinstance(data["key_risks"], list)
+        assert len(data["key_risks"]) >= 1
+        risk = data["key_risks"][0]
+        assert "severity" in risk
+        assert "title" in risk
+        assert "description" in risk
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_missing_clauses(self, mock_claude, client, auth_headers):
+        mock_claude.return_value = MOCK_MISSING_CLAUSES_RESPONSE
+        resp = client.post("/v1/missing-clauses", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "services",
+            "jurisdiction": "ON",
+        })
+        assert resp.status_code == 200, f"Missing clauses failed: {resp.text}"
+        data = resp.json()
+        assert "analysis_id" in data
+        assert isinstance(data["missing_clauses"], list)
+        assert len(data["missing_clauses"]) >= 1
+        clause = data["missing_clauses"][0]
+        assert "clause" in clause
+        assert "importance" in clause
+        assert "rationale" in clause
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_extract_clauses(self, mock_claude, client, auth_headers):
+        mock_claude.return_value = MOCK_EXTRACT_CLAUSES_RESPONSE
+        resp = client.post("/v1/extract-clauses", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "services",
+            "jurisdiction": "ON",
+        })
+        assert resp.status_code == 200, f"Extract clauses failed: {resp.text}"
+        data = resp.json()
+        assert "analysis_id" in data
+        assert isinstance(data["clauses"], list)
+        assert len(data["clauses"]) >= 1
+        clause = data["clauses"][0]
+        assert "type" in clause
+        assert "summary" in clause
+        assert "confidence" in clause
+
+
+# ─── 7. Contract Analysis — Validation Errors ───────────────────────────────
+
+
+class TestContractValidation:
+
+    @pytest.mark.parametrize("endpoint", [
+        "/v1/summary",
+        "/v1/risk-score",
+        "/v1/key-risks",
+        "/v1/missing-clauses",
+        "/v1/extract-clauses",
+    ])
+    def test_text_too_short(self, client, auth_headers, endpoint):
+        resp = client.post(endpoint, headers=auth_headers, json={
+            "text": "Too short",
+        })
+        assert resp.status_code == 400
+        assert "100 characters" in resp.json().get("detail", "")
+
+    @pytest.mark.parametrize("endpoint", [
+        "/v1/summary",
+        "/v1/risk-score",
+        "/v1/key-risks",
+        "/v1/missing-clauses",
+        "/v1/extract-clauses",
+    ])
+    def test_text_too_long(self, client, auth_headers, endpoint):
+        resp = client.post(endpoint, headers=auth_headers, json={
+            "text": "X" * 50001,
+        })
+        assert resp.status_code == 400
+        assert "50,000" in resp.json().get("detail", "")
+
+
+# ─── 8. File Upload ──────────────────────────────────────────────────────────
+
+
+class TestFileUpload:
+
+    def test_upload_txt_file(self, client, auth_headers):
+        content = SAMPLE_CONTRACT.encode("utf-8")
+        files = {"file": ("test_contract.txt", io.BytesIO(content), "text/plain")}
+        resp = client.post("/v1/upload", headers=auth_headers, files=files)
+        assert resp.status_code == 200, f"Upload failed: {resp.text}"
+        data = resp.json()
+        assert data["filename"] == "test_contract.txt"
+        assert data["char_count"] > 0
+        assert data["word_count"] > 0
+        assert len(data["text"]) > 50
+
+    def test_upload_no_auth(self, client):
+        content = b"Some contract text content here for testing purposes."
+        files = {"file": ("test.txt", io.BytesIO(content), "text/plain")}
+        resp = client.post("/v1/upload", files=files)
+        assert resp.status_code == 401
+
+    def test_upload_empty_file(self, client, auth_headers):
+        files = {"file": ("empty.txt", io.BytesIO(b""), "text/plain")}
+        resp = client.post("/v1/upload", headers=auth_headers, files=files)
+        assert resp.status_code == 422
+
+
+# ─── 9. Procurement Tools ───────────────────────────────────────────────────
+
+
+class TestProcurementLint:
+
+    def test_lint_document(self, client, auth_headers):
+        text = (
+            "The party of the first part hereinafter referred to as the Vendor "
+            "shall indemnify and hold harmless the party of the second part. "
+            "Notwithstanding the foregoing, the aforementioned obligations shall "
+            "be subject to the provisions herein. The parties agree that all "
+            "deliverables shall be provided in accordance with the terms and "
+            "conditions set forth hereinafter."
+        )
+        resp = client.post("/v1/procurement/lint", headers=auth_headers, json={
+            "text": text,
+        })
+        assert resp.status_code == 200, f"Lint failed: {resp.text}"
+        data = resp.json()
+        assert "total_issues" in data
+        assert "legalese" in data
+        assert "passive_voice" in data
+        assert "plural_parties" in data
+        assert "gendered_language" in data
+        assert isinstance(data["legalese"], list)
+        # Should find legalese like "hereinafter", "notwithstanding", "herein"
+        assert data["total_issues"] > 0, "Linter should find legalese issues"
+        legalese_terms = [item["term"].lower() for item in data["legalese"]]
+        assert any("herein" in t for t in legalese_terms), "Should detect 'herein'"
+
+    def test_lint_text_too_short(self, client, auth_headers):
+        resp = client.post("/v1/procurement/lint", headers=auth_headers, json={
+            "text": "Short.",
+        })
+        assert resp.status_code == 400
+
+    def test_lint_clean_text(self, client, auth_headers):
+        text = (
+            "The Contractor will deliver the software within 30 days of signing. "
+            "The Client will pay for the services within 15 days of receiving the "
+            "invoice. Both parties agree to the terms."
+        )
+        resp = client.post("/v1/procurement/lint", headers=auth_headers, json={
+            "text": text,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        # Clean text should have minimal issues
+        assert data["total_issues"] >= 0
+
+
+class TestProcurementCitations:
+
+    def test_validate_citations_with_statutes(self, client, auth_headers):
+        text = (
+            "This contract is governed by the Competition Act, RSC 1985, c C-34. "
+            "See also the Employment Standards Act, SO 2000, c 41."
+        )
+        resp = client.post("/v1/procurement/citations", headers=auth_headers, json={
+            "text": text,
+        })
+        assert resp.status_code == 200, f"Citations failed: {resp.text}"
+        data = resp.json()
+        assert "total" in data
+        assert "statutes" in data
+        assert "regulations" in data
+        assert "cases" in data
+        assert isinstance(data["statutes"], list)
+        assert data["total"] >= 1, "Should find at least one statute citation"
+
+    def test_validate_citations_with_cases(self, client, auth_headers):
+        text = (
+            "The Supreme Court held in Canada v Bedford, 2013 SCC 72 that the "
+            "provisions were unconstitutional."
+        )
+        resp = client.post("/v1/procurement/citations", headers=auth_headers, json={
+            "text": text,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 1, "Should find case citation"
+
+    def test_citations_no_citations(self, client, auth_headers):
+        resp = client.post("/v1/procurement/citations", headers=auth_headers, json={
+            "text": "This is a plain text document with no legal citations at all in it whatsoever.",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+
+
+class TestProcurementClauses:
+
+    def test_search_clauses(self, client, auth_headers):
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "indemnification",
+        })
+        assert resp.status_code == 200, f"Clause search failed: {resp.text}"
+        data = resp.json()
+        assert "total" in data
+        assert "categories" in data
+        assert "clauses" in data
+        assert isinstance(data["clauses"], list)
+        assert data["total"] > 0, "Should find indemnification clauses"
+
+    def test_search_clauses_with_category(self, client, auth_headers):
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "liability",
+            "category": "Limitation of Liability",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "clauses" in data
+
+    def test_list_all_clauses(self, client, auth_headers):
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total" in data
+        assert data["total"] > 0, "Clause library should not be empty"
+
+
+# ─── 10. Procurement AI — Clause Analysis & Semantic Search ─────────────────
+
+
+class TestProcurementClauseAI:
+
+    @patch("app.nlp.search.search_similar_clauses", return_value=[])
+    def test_analyze_clause(self, mock_search, client, auth_headers):
+        resp = client.post("/v1/procurement/clauses/analyze", headers=auth_headers, json={
+            "text": SAMPLE_CLAUSE_TEXT,
+        })
+        assert resp.status_code == 200, f"Analyze clause: {resp.status_code} {resp.text}"
+        data = resp.json()
+        assert "clause_type" in data
+        assert "risk_level" in data
+        assert data["risk_level"] in ("High", "Medium", "Low")
+
+    @patch("app.nlp.search.search_similar_clauses", return_value=[])
+    def test_semantic_search(self, mock_search, client, auth_headers):
+        resp = client.post("/v1/procurement/clauses/search", headers=auth_headers, json={
+            "query": "indemnification clause for government contracts",
+            "k": 3,
+        })
+        assert resp.status_code == 200, f"Semantic search: {resp.status_code} {resp.text}"
+        data = resp.json()
+        assert "total" in data
+        assert "clauses" in data
+
+    def test_clause_library(self, client, auth_headers):
+        resp = client.get("/v1/procurement/clauses/library", headers=auth_headers)
+        assert resp.status_code == 200, f"Library: {resp.status_code} {resp.text}"
+        data = resp.json()
+        assert "total" in data
+        assert "clauses" in data
+
+
+# ─── 11. Procurement AI — Contract Comparison ───────────────────────────────
+
+
+class TestProcurementCompare:
+
+    def test_compare_clauses(self, client, auth_headers):
+        resp = client.post("/v1/procurement/compare/clauses", headers=auth_headers, json={
+            "clause_a": "The Contractor shall indemnify the Crown against all claims.",
+            "clause_b": (
+                "The Vendor shall hold harmless and indemnify the Government "
+                "from any and all claims, losses, and damages."
+            ),
+        })
+        assert resp.status_code == 200, f"Compare clauses: {resp.status_code} {resp.text}"
+        data = resp.json()
+        assert "similarity_score" in data
+        assert "verdict" in data
+        assert 0.0 <= data["similarity_score"] <= 1.0
+
+
+# ─── 12. Ingestion (Role-Based Access) ──────────────────────────────────────
+
+
+class TestIngestion:
+
+    def test_list_tenders(self, client, auth_headers):
+        resp = client.get("/v1/procurement/ingestion/tenders", headers=auth_headers)
+        # procurement role should have access
+        assert resp.status_code == 200, f"Tenders: {resp.status_code} {resp.text}"
+        data = resp.json()
+        assert "total" in data
+        assert "tenders" in data
+
+    def test_trigger_ingestion_requires_admin(self, client, auth_headers):
+        """Non-admin (procurement) users should be forbidden."""
+        resp = client.post("/v1/procurement/ingestion/run", headers=auth_headers, json={
+            "query": "test",
+        })
+        assert resp.status_code == 403, f"Ingestion: {resp.status_code} {resp.text}"
+
+
+# ─── 13. Cross-Cutting Concerns ─────────────────────────────────────────────
+
+
+class TestCrossCutting:
+
+    def test_cors_preflight(self, client):
+        # Use an allowed origin from the test config (localhost:3000)
+        resp = client.options("/v1/summary", headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "Authorization, Content-Type",
+        })
+        assert resp.status_code == 200
+        assert "access-control-allow-origin" in resp.headers
+
+    def test_404_for_unknown_route(self, client):
+        resp = client.get("/v1/nonexistent-endpoint")
+        assert resp.status_code in (401, 404)
+
+    def test_method_not_allowed(self, client, auth_headers):
+        resp = client.delete("/v1/summary", headers=auth_headers)
+        assert resp.status_code == 405
+
+    def test_missing_request_body(self, client, auth_headers):
+        resp = client.post("/v1/summary", headers=auth_headers)
+        assert resp.status_code == 422
+
+    def test_invalid_json_body(self, client, auth_headers):
+        resp = client.post(
+            "/v1/summary",
+            headers={**auth_headers, "Content-Type": "application/json"},
+            content=b"not-json",
+        )
+        assert resp.status_code == 422

--- a/tests/test_frontend_e2e.py
+++ b/tests/test_frontend_e2e.py
@@ -1,0 +1,598 @@
+"""
+Frontend E2E tests for Procurement Intelligence.
+
+Tests the full user journey through the procurement-intelligence.html page:
+  1. HTML structure validation (panels, forms, IDs the JS depends on)
+  2. Auth flow (register -> login -> JWT -> API calls)
+  3. All 7 tool panels hit the correct API endpoints with the right payloads
+  4. Response format matches what the frontend rendering code expects
+  5. Main index.html and procurement.html page structure
+"""
+
+import io
+from unittest.mock import patch, AsyncMock, MagicMock
+import pytest
+from pathlib import Path
+
+from tests.conftest import (
+    SAMPLE_CONTRACT,
+    SAMPLE_CLAUSE_TEXT,
+    MOCK_SUMMARY_RESPONSE,
+    MOCK_RISK_SCORE_RESPONSE,
+    MOCK_KEY_RISKS_RESPONSE,
+    MOCK_MISSING_CLAUSES_RESPONSE,
+    MOCK_EXTRACT_CLAUSES_RESPONSE,
+)
+
+WEBSITE_DIR = Path(__file__).resolve().parent.parent / "website"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# HTML STRUCTURE VALIDATION
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestProcurementIntelligenceHTML:
+    """Validate the procurement-intelligence.html has all IDs the JS relies on."""
+
+    @pytest.fixture(scope="class")
+    def html(self):
+        return (WEBSITE_DIR / "procurement-intelligence.html").read_text()
+
+    # -- Auth gate elements --
+    def test_auth_gate_exists(self, html):
+        assert 'id="auth-gate"' in html
+
+    def test_login_form_elements(self, html):
+        assert 'id="login-username"' in html
+        assert 'id="login-password"' in html
+        assert 'id="login-msg"' in html
+        assert "doLogin()" in html
+
+    def test_register_form_elements(self, html):
+        assert 'id="reg-username"' in html
+        assert 'id="reg-email"' in html
+        assert 'id="reg-password"' in html
+        assert 'id="reg-role"' in html
+        assert 'id="reg-msg"' in html
+        assert "doRegister()" in html
+
+    # -- Main app container --
+    def test_app_container(self, html):
+        assert 'id="pai-app"' in html
+        assert 'id="user-display"' in html
+        assert 'id="role-display"' in html
+        assert "doLogout()" in html
+
+    # -- All 7 tool panel tabs exist --
+    @pytest.mark.parametrize("panel_id", [
+        "panel-linter",
+        "panel-citations",
+        "panel-clauses-basic",
+        "panel-analyze",
+        "panel-search",
+        "panel-tenders",
+        "panel-compare",
+    ])
+    def test_panel_exists(self, html, panel_id):
+        assert f'id="{panel_id}"' in html
+
+    # -- Linter panel elements --
+    def test_linter_panel_elements(self, html):
+        assert 'id="linter-input"' in html
+        assert 'id="linter-status"' in html
+        assert 'id="linter-results"' in html
+        assert 'id="linter-metrics"' in html
+        assert 'id="linter-groups"' in html
+        assert "runLinter()" in html
+
+    # -- Citations panel elements --
+    def test_citations_panel_elements(self, html):
+        assert 'id="citations-input"' in html
+        assert 'id="citations-status"' in html
+        assert 'id="citations-results"' in html
+        assert 'id="citations-metrics"' in html
+        assert 'id="citations-groups"' in html
+        assert "runCitations()" in html
+
+    # -- Clause library (basic) panel elements --
+    def test_clause_library_panel_elements(self, html):
+        assert 'id="basic-query"' in html
+        assert 'id="basic-category"' in html
+        assert 'id="basic-results"' in html
+        assert "runBasicSearch()" in html
+
+    # -- Analyze panel elements --
+    def test_analyze_panel_elements(self, html):
+        assert 'id="analyze-input"' in html
+        assert 'id="analyze-status"' in html
+        assert 'id="analyze-result"' in html
+        assert "analyzeClause()" in html
+
+    # -- Search panel elements --
+    def test_search_panel_elements(self, html):
+        assert 'id="search-input"' in html
+        assert 'id="search-type"' in html
+        assert 'id="search-result"' in html
+        assert "searchClauses()" in html
+
+    # -- Tenders panel elements --
+    def test_tenders_panel_elements(self, html):
+        assert 'id="tender-source"' in html
+        assert 'id="tender-status"' in html
+        assert 'id="tender-result"' in html
+        assert 'id="ingest-btn"' in html
+        assert "loadTenders()" in html
+        assert "triggerIngestion()" in html
+
+    # -- Compare panel elements --
+    def test_compare_panel_elements(self, html):
+        assert 'id="compare-a"' in html
+        assert 'id="compare-b"' in html
+        assert 'id="compare-status"' in html
+        assert 'id="compare-result"' in html
+        assert "compareClauses()" in html
+
+    # -- JavaScript API constants --
+    def test_api_base_url(self, html):
+        assert 'api.lexara.tech/v1' in html
+
+    def test_auth_headers_function(self, html):
+        assert "authHeaders()" in html
+        assert "Bearer" in html
+
+    # -- Navigation --
+    def test_navigation_links(self, html):
+        assert 'href="/#features"' in html
+        assert 'href="/#demo"' in html
+        assert 'href="/#pricing"' in html
+        assert 'href="/procurement-intelligence.html"' in html
+
+
+class TestIndexHTML:
+    """Validate main landing page structure."""
+
+    @pytest.fixture(scope="class")
+    def html(self):
+        return (WEBSITE_DIR / "index.html").read_text()
+
+    def test_has_demo_section(self, html):
+        assert 'id="demo"' in html or 'id="demo-placeholder"' in html
+
+    def test_has_features_section(self, html):
+        assert 'id="features"' in html or "features" in html.lower()
+
+    def test_has_pricing_section(self, html):
+        assert 'id="pricing"' in html or "pricing" in html.lower()
+
+    def test_links_to_procurement(self, html):
+        assert "procurement" in html.lower()
+
+    def test_references_api(self, html):
+        # index.html loads script.js which contains the API base URL
+        assert 'script.js' in html
+
+
+class TestProcurementHTML:
+    """Validate procurement.html page structure."""
+
+    @pytest.fixture(scope="class")
+    def html(self):
+        return (WEBSITE_DIR / "procurement.html").read_text()
+
+    def test_has_linter_tab(self, html):
+        assert "Readability Linter" in html or "linter" in html.lower()
+
+    def test_has_citation_tab(self, html):
+        assert "Citation" in html
+
+    def test_has_clause_library(self, html):
+        assert "Clause Library" in html or "clause" in html.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FRONTEND API CONTRACT TESTS
+# Simulate exactly what the JS does: register, login, then call each tool panel
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFrontendAuthFlow:
+    """Simulate the procurement-intelligence.html auth gate JS flow."""
+
+    def test_full_auth_journey(self, client):
+        """doRegister() -> switchAuthTab('login') -> doLogin() -> showApp()"""
+        import uuid
+        uid = uuid.uuid4().hex[:6]
+
+        # 1. doRegister() — POST /v1/auth/register
+        reg_resp = client.post("/v1/auth/register", json={
+            "username": f"fe_test_{uid}",
+            "email": f"fe_test_{uid}@lexara.dev",
+            "password": "FrontendTest123!",
+            "role": "procurement",
+        })
+        assert reg_resp.status_code == 200
+        assert reg_resp.json()["username"] == f"fe_test_{uid}"
+
+        # 2. doLogin() — POST /v1/auth/login
+        login_resp = client.post("/v1/auth/login", json={
+            "username": f"fe_test_{uid}",
+            "password": "FrontendTest123!",
+        })
+        assert login_resp.status_code == 200
+        data = login_resp.json()
+        # Frontend stores: localStorage.setItem("pai_token", data.access_token)
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+        assert data["role"] == "procurement"
+        # Token must be long enough to pass middleware (>= 10 chars)
+        assert len(data["access_token"]) >= 10
+
+
+class TestFrontendLinterPanel:
+    """Simulate runLinter() — POST /v1/procurement/lint"""
+
+    def test_linter_response_format(self, client, auth_headers):
+        """Frontend renders: data.total_issues, data.legalese, data.passive_voice,
+        data.plural_parties, data.gendered_language — each an array of findings."""
+        text = (
+            "Notwithstanding the foregoing provisions herein, the party of the "
+            "first part hereinafter referred to as the Vendor shall indemnify "
+            "and hold harmless the party of the second part. The deliverables "
+            "shall be provided in accordance with the terms hereinafter."
+        )
+        resp = client.post("/v1/procurement/lint", headers=auth_headers, json={"text": text})
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Fields the frontend rendering code expects
+        assert "total_issues" in data
+        assert isinstance(data["total_issues"], int)
+        assert "legalese" in data
+        assert "passive_voice" in data
+        assert "plural_parties" in data
+        assert "gendered_language" in data
+
+        # Each should be a list
+        for key in ("legalese", "passive_voice", "plural_parties", "gendered_language"):
+            assert isinstance(data[key], list)
+
+        # Legalese findings should have the fields the JS renders
+        assert data["total_issues"] > 0
+        if data["legalese"]:
+            finding = data["legalese"][0]
+            assert "term" in finding
+            assert "suggestion" in finding
+            # Frontend renders f.original and f.revised for before/after
+            assert "original" in finding
+
+    def test_linter_finds_specific_terms(self, client, auth_headers):
+        """Frontend highlights specific legalese terms."""
+        text = (
+            "The party hereby agrees to the terms set forth herein. "
+            "Notwithstanding the above provisions, the obligations "
+            "hereunder shall be binding. Pursuant to section 5, the "
+            "contractor forthwith shall deliver the goods."
+        )
+        resp = client.post("/v1/procurement/lint", headers=auth_headers, json={"text": text})
+        data = resp.json()
+        terms = [f["term"].lower() for f in data["legalese"]]
+        assert any("hereby" in t for t in terms)
+        assert any("herein" in t for t in terms)
+        assert any("notwithstanding" in t for t in terms)
+
+
+class TestFrontendCitationPanel:
+    """Simulate runCitations() — POST /v1/procurement/citations"""
+
+    def test_citation_response_format(self, client, auth_headers):
+        """Frontend renders: data.total, data.statutes[], data.regulations[], data.cases[]"""
+        text = (
+            "The Competition Act, RSC 1985, c C-34 governs this arrangement. "
+            "See also R v Jordan, 2016 SCC 27 for the framework."
+        )
+        resp = client.post("/v1/procurement/citations", headers=auth_headers, json={"text": text})
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "total" in data
+        assert "statutes" in data
+        assert "regulations" in data
+        assert "cases" in data
+        assert isinstance(data["statutes"], list)
+        assert isinstance(data["regulations"], list)
+        assert isinstance(data["cases"], list)
+        assert data["total"] >= 1
+
+        # Each citation should have: raw, valid, warnings (for frontend rendering)
+        if data["statutes"]:
+            s = data["statutes"][0]
+            assert "raw" in s
+            assert "warnings" in s
+            assert isinstance(s["warnings"], list)
+
+
+class TestFrontendClauseLibraryPanel:
+    """Simulate runBasicSearch() — POST /v1/procurement/clauses"""
+
+    def test_clause_search_response_format(self, client, auth_headers):
+        """Frontend renders: data.total, data.categories[], data.clauses[]"""
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "indemnification",
+            "category": None,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "total" in data
+        assert "categories" in data
+        assert "clauses" in data
+        assert isinstance(data["categories"], list)
+        assert isinstance(data["clauses"], list)
+        assert data["total"] > 0
+
+        # Frontend renders clause fields: id, title, category, text, source, notes
+        clause = data["clauses"][0]
+        assert "title" in clause
+        assert "text" in clause
+        assert "category" in clause
+
+    def test_clause_list_all_returns_categories(self, client, auth_headers):
+        """Frontend populates category dropdown from data.categories."""
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "",
+        })
+        data = resp.json()
+        assert len(data["categories"]) > 0
+        # Should include known categories
+        cats_lower = [c.lower() for c in data["categories"]]
+        assert any("indemnification" in c for c in cats_lower)
+
+    def test_clause_category_filter(self, client, auth_headers):
+        """Frontend filters by category via dropdown."""
+        resp = client.post("/v1/procurement/clauses", headers=auth_headers, json={
+            "query": "",
+            "category": "Termination",
+        })
+        data = resp.json()
+        assert data["total"] > 0
+
+
+class TestFrontendAnalyzePanel:
+    """Simulate analyzeClause() — POST /v1/procurement/clauses/analyze"""
+
+    @patch("app.nlp.search.search_similar_clauses", return_value=[])
+    def test_analyze_response_format(self, mock_search, client, auth_headers):
+        """Frontend renders: d.clause_type, d.risk_level, d.confidence_score,
+        d.improved, d.similar_clauses"""
+        resp = client.post("/v1/procurement/clauses/analyze", headers=auth_headers, json={
+            "text": SAMPLE_CLAUSE_TEXT,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Fields the frontend JS expects
+        assert "clause_type" in data
+        assert "risk_level" in data
+        assert data["risk_level"] in ("High", "Medium", "Low")
+        assert "confidence_score" in data
+        # improved can be None or a string
+        assert "improved" in data or data.get("improved") is None
+
+    @patch("app.nlp.search.search_similar_clauses", return_value=[])
+    def test_analyze_detects_risky_language(self, mock_search, client, auth_headers):
+        """Frontend shows risk badge based on risk_level."""
+        risky_text = (
+            "The Contractor shall use reasonable efforts to deliver the goods "
+            "as soon as possible and provide services as needed, at its discretion."
+        )
+        resp = client.post("/v1/procurement/clauses/analyze", headers=auth_headers, json={
+            "text": risky_text,
+        })
+        data = resp.json()
+        assert data["risk_level"] in ("High", "Medium")
+        # Should suggest improvements for vague language
+        if data.get("improved"):
+            assert data["improved"] != risky_text
+
+
+class TestFrontendSemanticSearchPanel:
+    """Simulate searchClauses() — POST /v1/procurement/clauses/search"""
+
+    @patch("app.nlp.search.search_similar_clauses", return_value=[])
+    def test_search_response_format(self, mock_search, client, auth_headers):
+        """Frontend renders: d.total, d.clauses[]"""
+        resp = client.post("/v1/procurement/clauses/search", headers=auth_headers, json={
+            "query": "indemnification for government contracts",
+            "k": 5,
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "total" in data
+        assert "clauses" in data
+        assert isinstance(data["clauses"], list)
+
+
+class TestFrontendTendersPanel:
+    """Simulate loadTenders() — GET /v1/procurement/ingestion/tenders"""
+
+    def test_tenders_response_format(self, client, auth_headers):
+        """Frontend renders: d.total, d.tenders[] with source, title, buyer, value, currency, country, source_url"""
+        resp = client.get("/v1/procurement/ingestion/tenders?limit=50", headers=auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "total" in data
+        assert "tenders" in data
+        assert isinstance(data["tenders"], list)
+
+    def test_ingestion_blocked_for_non_admin(self, client, auth_headers):
+        """Frontend hides ingest-btn for non-admin; API enforces 403."""
+        resp = client.post("/v1/procurement/ingestion/run", headers=auth_headers, json={
+            "query": "procurement",
+        })
+        assert resp.status_code == 403
+
+
+class TestFrontendComparePanel:
+    """Simulate compareClauses() — POST /v1/procurement/compare/clauses"""
+
+    def test_compare_response_format(self, client, auth_headers):
+        """Frontend renders: d.similarity_score, d.verdict, d.match"""
+        resp = client.post("/v1/procurement/compare/clauses", headers=auth_headers, json={
+            "clause_a": "The Contractor shall indemnify the Crown against all claims.",
+            "clause_b": (
+                "The Vendor shall hold harmless and indemnify the Government "
+                "from any and all claims, losses, and damages."
+            ),
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+
+        # Fields the frontend JS expects
+        assert "similarity_score" in data
+        assert "verdict" in data
+        assert "match" in data
+        assert isinstance(data["similarity_score"], float)
+        assert 0.0 <= data["similarity_score"] <= 1.0
+        assert isinstance(data["match"], bool)
+        assert isinstance(data["verdict"], str)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# INDEX.HTML CONTRACT ANALYSIS — simulate script.js calls
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFrontendContractAnalysis:
+    """Simulate script.js tab clicks on index.html — each tab calls a different endpoint."""
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_summary_tab_response_format(self, mock_claude, client, auth_headers):
+        """Tab 1: script.js calls /v1/summary and renders result.summary, result.contract_type, etc."""
+        mock_claude.return_value = MOCK_SUMMARY_RESPONSE
+        resp = client.post("/v1/summary", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "auto",
+            "jurisdiction": "ON",
+        })
+        data = resp.json()
+        # script.js renders: result.summary, result.contract_type, result.confidence
+        assert "summary" in data
+        assert "contract_type" in data
+        assert "confidence" in data
+        assert isinstance(data["confidence"], float)
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_risk_score_tab_response_format(self, mock_claude, client, auth_headers):
+        """Tab 2: script.js renders risk score bar and category breakdown."""
+        mock_claude.return_value = MOCK_RISK_SCORE_RESPONSE
+        resp = client.post("/v1/risk-score", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "auto",
+            "jurisdiction": "ON",
+        })
+        data = resp.json()
+        assert "overall_risk_score" in data
+        assert "risk_level" in data
+        assert "scores_by_category" in data
+        assert isinstance(data["scores_by_category"], dict)
+        # script.js renders per-category bars
+        for cat in ("liability", "data_protection", "termination", "ip_ownership", "warranty"):
+            assert cat in data["scores_by_category"]
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_key_risks_tab_response_format(self, mock_claude, client, auth_headers):
+        """Tab 3: script.js renders risk cards with severity badges."""
+        mock_claude.return_value = MOCK_KEY_RISKS_RESPONSE
+        resp = client.post("/v1/key-risks", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "auto",
+            "jurisdiction": "ON",
+        })
+        data = resp.json()
+        assert "key_risks" in data
+        assert isinstance(data["key_risks"], list)
+        for risk in data["key_risks"]:
+            assert "severity" in risk
+            assert "title" in risk
+            assert "description" in risk
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_missing_clauses_tab_response_format(self, mock_claude, client, auth_headers):
+        """Tab 4: script.js renders missing clause cards."""
+        mock_claude.return_value = MOCK_MISSING_CLAUSES_RESPONSE
+        resp = client.post("/v1/missing-clauses", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "auto",
+            "jurisdiction": "ON",
+        })
+        data = resp.json()
+        assert "missing_clauses" in data
+        for mc in data["missing_clauses"]:
+            assert "clause" in mc
+            assert "importance" in mc
+            assert "rationale" in mc
+
+    @patch("app.routers.contracts.analyze_with_claude", new_callable=AsyncMock)
+    def test_extract_clauses_tab_response_format(self, mock_claude, client, auth_headers):
+        """Tab 5: script.js renders clause revision cards."""
+        mock_claude.return_value = MOCK_EXTRACT_CLAUSES_RESPONSE
+        resp = client.post("/v1/extract-clauses", headers=auth_headers, json={
+            "text": SAMPLE_CONTRACT,
+            "contract_type": "auto",
+            "jurisdiction": "ON",
+        })
+        data = resp.json()
+        assert "clauses" in data
+        for c in data["clauses"]:
+            assert "type" in c
+            assert "summary" in c
+            assert "confidence" in c
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# FILE UPLOAD — simulate the upload zone on index.html
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFrontendFileUpload:
+    """Simulate the drag-and-drop / browse upload flow on index.html."""
+
+    def test_upload_returns_text_for_analysis(self, client, auth_headers):
+        """Frontend uses the returned text to populate the textarea for analysis."""
+        content = SAMPLE_CONTRACT.encode("utf-8")
+        files = {"file": ("contract.txt", io.BytesIO(content), "text/plain")}
+        resp = client.post("/v1/upload", headers=auth_headers, files=files)
+        assert resp.status_code == 200
+        data = resp.json()
+        # Frontend needs: filename, text, char_count, word_count
+        assert "filename" in data
+        assert "text" in data
+        assert "char_count" in data
+        assert "word_count" in data
+        assert len(data["text"]) >= 100  # enough for analysis endpoints
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# BILLING — simulate pricing page checkout flow
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFrontendBilling:
+
+    def test_plans_response_has_all_tiers(self, client, auth_headers):
+        """Frontend renders 4 pricing cards from data.plans."""
+        resp = client.get("/v1/plans", headers=auth_headers)
+        data = resp.json()
+        plans = data["plans"]
+        assert "free" in plans
+        assert "starter" in plans
+        assert "growth" in plans
+        assert "business" in plans
+        # Each plan has fields the frontend renders
+        for plan_key, plan in plans.items():
+            assert "name" in plan
+            assert "price_cad" in plan
+            assert "analyses_limit" in plan

--- a/tests/test_frontend_e2e.py
+++ b/tests/test_frontend_e2e.py
@@ -43,6 +43,13 @@ class TestProcurementIntelligenceHTML:
     def test_auth_gate_exists(self, html):
         assert 'id="auth-gate"' in html
 
+    def test_show_app_uses_block_not_empty_string(self, html):
+        """Regression: style.display='' does NOT override CSS 'display:none' rules.
+        showApp() must set display='block' to override the #pai-app CSS rule."""
+        assert '.style.display = "block"' in html or ".style.display = 'block'" in html
+        # Must NOT use empty string to show #pai-app
+        assert 'getElementById("pai-app").style.display = ""' not in html
+
     def test_login_form_elements(self, html):
         assert 'id="login-username"' in html
         assert 'id="login-password"' in html

--- a/website/procurement-ai.html
+++ b/website/procurement-ai.html
@@ -424,12 +424,12 @@ function doLogout() {
   localStorage.removeItem("pai_user");
   _token = _role = _user = null;
   document.getElementById("pai-app").style.display = "none";
-  document.getElementById("auth-gate").style.display = "";
+  document.getElementById("auth-gate").style.display = "block";
 }
 
 function showApp() {
   document.getElementById("auth-gate").style.display = "none";
-  document.getElementById("pai-app").style.display = "";
+  document.getElementById("pai-app").style.display = "block";
   document.getElementById("user-display").textContent = _user;
   document.getElementById("role-display").textContent  = _role;
   if (_role === "admin") document.getElementById("ingest-btn").style.display = "";

--- a/website/procurement-intelligence.html
+++ b/website/procurement-intelligence.html
@@ -481,12 +481,12 @@ function doLogout() {
   localStorage.removeItem("pai_user");
   _token = _role = _user = null;
   document.getElementById("pai-app").style.display = "none";
-  document.getElementById("auth-gate").style.display = "";
+  document.getElementById("auth-gate").style.display = "block";
 }
 
 function showApp() {
   document.getElementById("auth-gate").style.display = "none";
-  document.getElementById("pai-app").style.display = "";
+  document.getElementById("pai-app").style.display = "block";
   document.getElementById("user-display").textContent = _user;
   document.getElementById("role-display").textContent  = _role;
   if (_role === "admin") document.getElementById("ingest-btn").style.display = "";


### PR DESCRIPTION
## Summary

- **Fix:** Procurement Intelligence page was completely blank after login — `showApp()` used `style.display = ""` which does not override the CSS rule `#pai-app { display: none }`. Changed to `style.display = "block"` in both `procurement-intelligence.html` and `procurement-ai.html`.
- **Tests:** Added comprehensive E2E test suite (111 tests) covering all API endpoints and frontend contract validation.

## Changes

### Bug Fix
- `website/procurement-intelligence.html` — `showApp()` and `doLogout()` now use `display = "block"` instead of `""`
- `website/procurement-ai.html` — same fix applied

### E2E Test Suite (111 tests, ~3s)
- **Backend API** (61 tests): health, auth flow, auth enforcement on 11 endpoints, billing/plans, usage, contract analysis (5 tabs with mocked Claude), input validation, file upload, procurement tools (linter, citations, clauses), AI clause analysis, semantic search, tenders, comparison, ingestion RBAC, CORS, error handling
- **Frontend** (50 tests): HTML structure validation for all 7 Procurement Intelligence panels, API contract tests simulating the exact JS calls, regression test for the display bug

### Infrastructure
- `.gitignore` for Python artifacts

## Test plan
- [x] All 111 tests pass locally (`pytest tests/ -v`)
- [ ] Verify Procurement Intelligence page shows tool tabs after login on lexara.tech
- [ ] Test each panel: Readability Linter, Citation Validator, Clause Library, AI Clause Analysis, Semantic Search, Live Tenders, Compare

https://claude.ai/code/session_012DSnkANy2L4Bwt2DJexmiV