### PR TITLE
feat: add /status endpoint with version, uptime, and DB check

### DIFF
--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -14,6 +14,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     # Routes that don't require authentication (exact match)
     UNPROTECTED_ROUTES = {
         "/health",
+        "/status",
         "/docs",
         "/redoc",
         "/openapi.json",

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,9 +1,19 @@
 """Health check endpoints."""
 
+import time
+from datetime import datetime, timezone
+
 from fastapi import APIRouter
-from datetime import datetime
+from sqlalchemy import text
+
+from app.config import settings
+from app.database.session import engine
 
 router = APIRouter()
+
+# Captured at import so /status can report process uptime.
+_STARTED_MONOTONIC = time.monotonic()
+_STARTED_AT_ISO = datetime.now(timezone.utc).isoformat()
 
 
 @router.get("/health")
@@ -13,6 +23,36 @@ async def health_check():
         "status": "healthy",
         "timestamp": datetime.utcnow().isoformat(),
         "version": "1.0.0"
+    }
+
+
+@router.get("/status")
+async def status():
+    """Service status: version, uptime, environment, and dependency checks."""
+    db_status = "ok"
+    db_error: str | None = None
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as exc:
+        db_status = "error"
+        db_error = str(exc)
+
+    db_check: dict = {"status": db_status}
+    if db_error:
+        db_check["error"] = db_error
+
+    return {
+        "status": "ok" if db_status == "ok" else "degraded",
+        "service": settings.app_name,
+        "version": settings.version,
+        "environment": settings.environment,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "started_at": _STARTED_AT_ISO,
+        "uptime_seconds": round(time.monotonic() - _STARTED_MONOTONIC, 3),
+        "checks": {
+            "database": db_check,
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- Adds `GET /status` in `app/routers/health.py` returning service name, version, environment, ISO start time, monotonic uptime, current timestamp, and a live database check (`SELECT 1`).
- Registers `/status` in `APIKeyMiddleware.UNPROTECTED_ROUTES` so monitoring can poll without an API key (parallel to `/health`).
- Overall `status` reports `ok` when the DB check passes, `degraded` otherwise; the failing dependency carries its own `status`/`error` under `checks`.

## Test plan
- [ ] `curl http://localhost:8000/status` → 200 with `status: "ok"` and a positive `uptime_seconds`
- [ ] Stop the database → `/status` returns `degraded` with `checks.database.status == "error"`
- [ ] `/status` is reachable without an `Authorization` header (middleware bypass)
- [ ] Existing `/health` behavior unchanged

https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC)_