### PR TITLE
feat(negotiation): clause-weight calibration + move-quality label

### DIFF
--- a/app/routers/negotiation_routes.py
+++ b/app/routers/negotiation_routes.py
@@ -33,6 +33,7 @@ from app.models.negotiation import (
 )
 from app.security import get_current_user
 from app.services.audit_service import log_action
+from app.services.clause_weights import classify_move, clause_weight
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +177,10 @@ def _serialise_clause(clause: NegotiationClause) -> dict:
 
 
 def _serialise_round(rnd: NegotiationRound) -> dict:
+    clause = getattr(rnd, "clause", None)
+    clause_type = getattr(clause, "clause_type", None) if clause else None
+    risk_severity = getattr(clause, "risk_severity", None) if clause else None
+
     return {
         "id": rnd.id,
         "clause_id": rnd.clause_id,
@@ -187,6 +192,8 @@ def _serialise_round(rnd: NegotiationRound) -> dict:
         "trade_offer": rnd.trade_offer,
         "dollar_value_cad": float(rnd.dollar_value_cad) if rnd.dollar_value_cad is not None else None,
         "ai_confidence": rnd.ai_confidence,
+        "move_quality": classify_move(rnd.action, rnd.ai_confidence, clause_type, risk_severity),
+        "clause_weight": clause_weight(clause_type),
         "created_at": rnd.created_at.isoformat() if rnd.created_at else None,
     }
 

--- a/app/services/clause_weights.py
+++ b/app/services/clause_weights.py
@@ -1,0 +1,146 @@
+"""
+Clause weight + move-quality calibration.
+
+Single source of truth for the numeric constants that several services
+(`negotiation_ai`, `batna_engine`, `linter_service`) had been re-deriving
+inline. Centralising them here keeps the dollar-value math, BATNA leverage,
+and the move-quality label that the ledger surfaces consistent.
+
+The weights are advisory strategic weights — they do NOT replace
+`risk_exposure_cad`, which remains the user-facing financial number.
+"""
+
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Per-clause-type strategic weight (0–1000)
+# ---------------------------------------------------------------------------
+# How much a single concession on this clause type shifts the overall
+# negotiation. Calibrated against the historical clause types already used
+# throughout `negotiation_ai.py` (TRADE_PAIR_SUCCESS_RATES, GOVERNMENT_NON_NEGOTIABLES).
+
+CLAUSE_TYPE_WEIGHT: dict[str, int] = {
+    "indemnification": 900,
+    "indemnity": 900,
+    "limitation_of_liability": 700,
+    "liability_cap": 700,
+    "liability": 700,
+    "ip_ownership": 600,
+    "crown_ip_vesting": 600,
+    "data_residency": 500,
+    "privacy_act_compliance": 500,
+    "atip_compliance": 500,
+    "audit_rights": 450,
+    "warranty": 400,
+    "termination": 350,
+    "sla": 300,
+    "acceptance_criteria": 300,
+    "payment_terms": 200,
+    "notice_period": 100,
+}
+
+DEFAULT_CLAUSE_WEIGHT = 250
+
+
+def clause_weight(clause_type: Optional[str]) -> int:
+    """Return the strategic weight for a clause type. Falls back to default."""
+    if not clause_type:
+        return DEFAULT_CLAUSE_WEIGHT
+    return CLAUSE_TYPE_WEIGHT.get(clause_type.lower(), DEFAULT_CLAUSE_WEIGHT)
+
+
+# ---------------------------------------------------------------------------
+# Severity → numeric score
+# ---------------------------------------------------------------------------
+
+SEVERITY_NUMERIC: dict[str, float] = {
+    "low": 0.30,
+    "medium": 0.60,
+    "high": 1.00,
+    "critical": 1.00,
+}
+
+
+def severity_to_score(severity: Optional[str]) -> float:
+    """Map a severity label to a 0–1 score. Defaults to medium."""
+    if not severity:
+        return SEVERITY_NUMERIC["medium"]
+    return SEVERITY_NUMERIC.get(severity.lower(), SEVERITY_NUMERIC["medium"])
+
+
+# ---------------------------------------------------------------------------
+# Action → expected risk-recovery multiplier
+# ---------------------------------------------------------------------------
+# Used by `calculate_round_dollar_value` in negotiation_ai. Previously inlined.
+
+ACTION_RECOVERY_MULTIPLIER: dict[str, float] = {
+    "accept": 0.70,
+    "counter": 0.30,
+    "reject": 0.00,
+    "trade_offer": 0.00,  # value is realised when the trade resolves
+    "propose": 0.00,
+}
+
+
+def action_recovery(action: Optional[str]) -> float:
+    """Return the share of risk_exposure recovered for a given action."""
+    if not action:
+        return 0.0
+    return ACTION_RECOVERY_MULTIPLIER.get(action, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Move-quality classification
+# ---------------------------------------------------------------------------
+# Four-bucket label exposed on the ledger. Combines:
+#   - the action taken (accept / counter / reject / trade_offer)
+#   - the LLM's `ai_confidence` from the rule layer
+#   - the strategic weight of the clause
+# Quality is only meaningful for opponent rounds; user-side `propose`
+# rounds return None — quality emerges from the response.
+
+MOVE_QUALITY_LABELS = ("best", "acceptable", "risky", "critical")
+
+
+def classify_move(
+    action: Optional[str],
+    ai_confidence: Optional[float],
+    clause_type: Optional[str],
+    risk_severity: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Derive a four-bucket move-quality label for a negotiation round.
+
+    Returns one of: "best", "acceptable", "risky", "critical".
+    Returns None for actions that have no derivable quality yet
+    (e.g. the user's own `propose` round — quality is set when the
+    opponent responds).
+    """
+    if action in (None, "propose"):
+        return None
+
+    confidence = float(ai_confidence) if ai_confidence is not None else 0.5
+    weight = clause_weight(clause_type)
+    is_heavy = weight >= 500
+    severity_score = severity_to_score(risk_severity)
+
+    if action == "accept":
+        return "best" if confidence >= 0.65 else "acceptable"
+
+    if action == "trade_offer":
+        return "acceptable"
+
+    if action == "counter":
+        if confidence >= 0.55:
+            return "acceptable"
+        if is_heavy and severity_score >= 0.6:
+            return "risky"
+        return "acceptable"
+
+    if action == "reject":
+        if is_heavy and severity_score >= 0.6:
+            return "critical"
+        return "risky"
+
+    return None

--- a/app/services/negotiation_ai.py
+++ b/app/services/negotiation_ai.py
@@ -695,13 +695,7 @@ def calculate_round_dollar_value(clause_data: dict, action: str) -> float:
     -------
     float  — 0.0 if no value is attributable to this round
     """
+    from app.services.clause_weights import action_recovery
+
     risk_exposure = float(clause_data.get("risk_exposure_cad") or 0)
-
-    multipliers = {
-        "accept": 0.70,       # 70% of risk exposure is recovered on full acceptance
-        "counter": 0.30,      # partial movement
-        "reject": 0.0,        # no movement
-        "trade_offer": 0.0,   # value realised when the trade resolves
-    }
-
-    return round(risk_exposure * multipliers.get(action, 0.0), 2)
+    return round(risk_exposure * action_recovery(action), 2)


### PR DESCRIPTION
## Summary
Spike of items #1 and #3 from the negotiation-overlay plan. Non-breaking, additive only — no DB migration, no new model dependency, no chess vocabulary.

- **`app/services/clause_weights.py`** (new): single source of truth for per-clause-type strategic weights (indemnification 900 → notice_period 100), severity → 0–1 numeric mapping, and the action-recovery multipliers that `calculate_round_dollar_value` had inlined. Helpers: `clause_weight()`, `severity_to_score()`, `action_recovery()`, `classify_move()`.
- **`app/services/negotiation_ai.py`**: `calculate_round_dollar_value` now delegates to `action_recovery()`. Behaviour identical (accept=0.70, counter=0.30, reject=0.0, trade_offer=0.0).
- **`app/routers/negotiation_routes.py`**: `_serialise_round` now emits two additive response fields:
  - `move_quality`: one of `best | acceptable | risky | critical`, or `null` for the user's own `propose` rounds (quality emerges from the response).
  - `clause_weight`: the strategic weight for the round's clause type.

The `/ledger`, `/{session_id}`, and `/respond` endpoints inherit these fields automatically through the existing serialiser.

### Move-quality classification rules
| action | rule |
|---|---|
| `accept` | `best` if `ai_confidence ≥ 0.65`, else `acceptable` |
| `counter` | `acceptable` if `ai_confidence ≥ 0.55`; `risky` only on heavy clauses (≥500) with severity ≥ medium; otherwise `acceptable` |
| `reject` | `critical` on heavy clauses with severity ≥ medium; else `risky` |
| `trade_offer` | `acceptable` |
| `propose` | `null` |

## Test plan
- [x] Module imports + 11 logic assertions pass (`classify_move`, `clause_weight`, `action_recovery`, `severity_to_score`)
- [x] `py_compile` clean on all three files
- [ ] Full pytest suite green in CI
- [ ] Existing `/v1/negotiation/{id}/ledger` consumers see new optional fields without breaking
- [ ] `dollar_value_cad` continues to match pre-refactor values for accept / counter / reject / trade_offer

## What's deliberately NOT in this PR
- No new endpoint
- No DB column or migration
- No SaulLM / model dependency
- No UI surfacing — front-end can adopt `move_quality` when ready
- No chess terminology anywhere in the code or response shape

https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC)_