### PR TITLE
fix(deps): bump python-multipart 0.0.6 → 0.0.7 (GHSA-2jv5-9r88-3w3p, HIGH)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-dotenv==1.0.0
 pytest==7.4.3
 pytest-asyncio==0.23.1
 alembic==1.13.0
-python-multipart==0.0.6
+python-multipart==0.0.7
 aiofiles==23.2.1
 pypdf==4.1.0
 python-docx==1.1.0


### PR DESCRIPTION
⚠️ **DO NOT AUTO-MERGE — human review required**

## Security Advisory

| Field | Value |
|---|---|
| Advisory | [GHSA-2jv5-9r88-3w3p](https://github.com/advisories/GHSA-2jv5-9r88-3w3p) |
| CVE | CVE-2024-24762 |
| Severity | **HIGH** |
| Package | `python-multipart` (pip) |
| Vulnerable range | `< 0.0.7` |
| Before | `0.0.6` |
| After | `0.0.7` |

## Summary

`python-multipart` used a Regular Expression to parse the HTTP `Content-Type` header, including options. An attacker could send a crafted `Content-Type` option that is very difficult for the RegEx to process, causing CPU exhaustion and stalling the main event loop indefinitely (ReDoS). This makes the process unable to handle any additional requests. Only affects endpoints reading form data.

**Advisory URL:** https://github.com/advisories/GHSA-2jv5-9r88-3w3p

## Change

```
- python-multipart==0.0.6
+ python-multipart==0.0.7
```

## Test Results

```
pytest: 346 passed, 2 skipped (matches baseline)
```

## Notes

- Safe-bump path: direct dependency, patch-level bump within same minor series.
- Note: a Dependabot auto-PR (dependabot/pip/python-multipart-0.0.26) targeting a later version also exists; this PR addresses the specific HIGH-severity advisory GHSA-2jv5-9r88-3w3p at minimum patch.
- Alert data sourced from pip-audit (GHSA database) — Dependabot API was inaccessible (gh CLI not installed in environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYWVziJ2aC2nZ9SUwRVUkE)_