### PR TITLE
fix(deps): bump python-jose 3.3.0 → 3.4.0 (GHSA-6c5p-j8vq-pqhj, HIGH)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ spacy>=3.7.0
 sentence-transformers==2.3.1
 scikit-learn==1.4.0
 faiss-cpu==1.7.4
-python-jose[cryptography]==3.3.0
+python-jose[cryptography]==3.4.0
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
 slowapi==0.1.9


### PR DESCRIPTION
⚠️ **DO NOT AUTO-MERGE — human review required**

## Security Advisory

| Field | Value |
|---|---|
| Advisory | [GHSA-6c5p-j8vq-pqhj](https://github.com/advisories/GHSA-6c5p-j8vq-pqhj) |
| CVE | CVE-2024-33663 |
| Severity | **HIGH** |
| Package | `python-jose` (pip) |
| Vulnerable range | `<= 3.3.0` |
| Before | `3.3.0` |
| After | `3.4.0` |

## Summary

`python-jose` through 3.3.0 has algorithm confusion with OpenSSH ECDSA keys and other key formats (similar to CVE-2022-29217). An attacker who can supply a JWT signed with an unexpected key type could bypass JWT verification, leading to authentication bypass.

**Advisory URL:** https://github.com/advisories/GHSA-6c5p-j8vq-pqhj

**Related:** Also fixes GHSA-cjwg-qfpm-7377 / CVE-2024-33664 (JWT bomb DoS via high-compression JWE token).

## Change

```
- python-jose[cryptography]==3.3.0
+ python-jose[cryptography]==3.4.0
```

## Test Results

```
pytest: 346 passed, 2 skipped (matches baseline)
```

## Notes

- Safe-bump path: direct dependency, minor version bump (3.3.0 → 3.4.0).
- Alert data sourced from pip-audit (GHSA database) — Dependabot API was inaccessible (gh CLI not installed in environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYWVziJ2aC2nZ9SUwRVUkE)_