### PR TITLE
fix(deps): bump fastapi 0.109.0 → 0.116.0 to resolve starlette CVE (GHSA-f96h-pmfr-66vw, HIGH)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.109.0
+fastapi==0.116.0
 uvicorn[standard]==0.27.0
 pydantic==2.5.0
 pydantic-settings==2.1.0


### PR DESCRIPTION
⚠️ **DO NOT AUTO-MERGE — human review required**

## Security Advisory

| Field | Value |
|---|---|
| Advisory | [GHSA-f96h-pmfr-66vw](https://github.com/advisories/GHSA-f96h-pmfr-66vw) |
| CVE | CVE-2024-47874 |
| Severity | **HIGH** |
| Vulnerable package | `starlette` 0.35.1 (transitive) |
| Vulnerable range | `< 0.40.0` |
| Transitive path | `fastapi==0.109.0` → `starlette==0.35.1` |
| Fixed via | `fastapi==0.116.0` → `starlette==0.46.2` (satisfies `>=0.40.0`) |

## Summary

Starlette treats `multipart/form-data` parts without a `filename` field as text form fields and buffers them in byte strings with **no size limit**. An attacker can upload an arbitrarily large "text" field, exhausting server memory and taking down the process. Fixed in starlette 0.40.0.

**Advisory URL:** https://github.com/advisories/GHSA-f96h-pmfr-66vw

## Dependency Chain & Fix

`starlette` is a transitive dependency via `fastapi`:

- `fastapi 0.109.0` requires `starlette>=0.35.0,<0.36.0` (pins vulnerable version)
- `fastapi 0.116.0` requires `starlette>=0.40.0,<0.47.0` (pulls safe version)
- pip resolves to `starlette 0.46.2` with this PR

This is a **transitive-path fix**: bump the direct parent (`fastapi`) to get a safe `starlette`. The fastapi bump is minor-version only (0.109 → 0.116), not a major-version bump, so it does not trigger the core-framework skip rule.

## Change

```
- fastapi==0.109.0
+ fastapi==0.116.0
```
*(starlette pinned implicitly by fastapi; no other changes)*

## Test Results

```
pytest: 346 passed, 2 skipped (matches baseline)
starlette installed: 0.46.2 (≥ 0.40.0 ✓)
```

## Notes

- This bumps fastapi by 7 minor versions; reviewers should verify no API deprecations are relied upon in production paths beyond what tests cover.
- Alert data sourced from pip-audit + GHSA database — Dependabot API was inaccessible (gh CLI not installed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YYWVziJ2aC2nZ9SUwRVUkE)_