### PR TITLE
test(uat): nightly Playwright UAT against live deploy + .pptx report

### DIFF
--- a/.github/workflows/uat.yml
+++ b/.github/workflows/uat.yml
@@ -1,0 +1,66 @@
+name: UAT
+
+# End-to-end UAT against the live LexAra deployment.
+# Runs Playwright (Chromium) against lexara.tech / api.lexara.tech, captures
+# a screenshot per step, and emits a .pptx report uploaded as a workflow
+# artifact. Trigger manually from the Actions UI or wait for the nightly run.
+#
+# Optional repository secrets to enable the authenticated flow:
+#   UAT_TEST_USER_EMAIL
+#   UAT_TEST_USER_PASSWORD
+# (the suite skips that case cleanly if either is missing)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Public site base URL"
+        default: "https://lexara.tech"
+        required: false
+      api_base_url:
+        description: "API base URL"
+        default: "https://api.lexara.tech"
+        required: false
+  schedule:
+    # 03:00 UTC nightly
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  uat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: tests/uat/requirements.txt
+
+      - name: Install Python dependencies
+        run: pip install -r tests/uat/requirements.txt
+
+      - name: Install Playwright browser
+        run: python -m playwright install --with-deps chromium
+
+      - name: Run UAT
+        env:
+          UAT_BASE_URL: ${{ github.event.inputs.base_url || 'https://lexara.tech' }}
+          UAT_API_BASE_URL: ${{ github.event.inputs.api_base_url || 'https://api.lexara.tech' }}
+          UAT_TEST_USER_EMAIL: ${{ secrets.UAT_TEST_USER_EMAIL }}
+          UAT_TEST_USER_PASSWORD: ${{ secrets.UAT_TEST_USER_PASSWORD }}
+          UAT_OUTPUT_DIR: qa-reports/${{ github.run_number }}
+          UAT_HEADLESS: "1"
+        run: python tests/uat/run_uat.py
+
+      - name: Upload UAT report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uat-report-${{ github.run_number }}
+          path: qa-reports/${{ github.run_number }}
+          retention-days: 30

--- a/tests/uat/README.md
+++ b/tests/uat/README.md
@@ -1,0 +1,83 @@
+# LexAra UAT — End-to-end smoke against the live deployment
+
+Drives `lexara.tech` and `api.lexara.tech` with Playwright (Chromium),
+captures a screenshot per step, and writes a single `.pptx` summarising
+pass/fail per case.
+
+## Where it runs
+
+- **CI (default).** `.github/workflows/uat.yml` runs nightly at 03:00 UTC
+  and on demand via *Actions → UAT → Run workflow*. The `.pptx` and the
+  raw screenshots are attached as workflow artifacts, retained 30 days.
+- **Locally.** Useful for iterating on test cases before pushing.
+
+## Run locally
+
+```bash
+pip install -r tests/uat/requirements.txt
+python -m playwright install --with-deps chromium
+
+# Headed run against the live site (watch the browser drive)
+UAT_HEADLESS=0 python tests/uat/run_uat.py
+
+# Headless run against a staging URL
+UAT_BASE_URL=https://staging.lexara.tech \
+UAT_API_BASE_URL=https://staging-api.lexara.tech \
+python tests/uat/run_uat.py
+```
+
+The script writes:
+
+```
+qa-reports/<UTC-timestamp>/
+  Lexara_UAT_<UTC-timestamp>.pptx
+  screenshots/
+    landing_page.png
+    auth_page.png
+    ...
+```
+
+## Environment variables
+
+| Name | Default | Purpose |
+|---|---|---|
+| `UAT_BASE_URL` | `https://lexara.tech` | Public site under test |
+| `UAT_API_BASE_URL` | `https://api.lexara.tech` | API under test |
+| `UAT_OUTPUT_DIR` | `qa-reports/<timestamp>` | Where the report and screenshots go |
+| `UAT_HEADLESS` | `1` | Set `0` to watch the browser during local runs |
+| `UAT_TEST_USER_EMAIL` | unset | If set, runs the authenticated flow case |
+| `UAT_TEST_USER_PASSWORD` | unset | Pair with `UAT_TEST_USER_EMAIL` |
+
+## Cases covered (v1)
+
+API:
+- `GET /health` — 200 with `status` field
+- `GET /status` — 200 with `service`, `version`, `uptime_seconds`
+
+Frontend (per page: load, assert `<title>`, full-page screenshot):
+- `/` — Landing
+- `/auth.html` — Sign in
+- `/procurement.html` — Procurement Tools
+- `/procurement-ai.html` — Procurement AI
+- `/procurement-intelligence.html` — Procurement Intelligence
+- `/negotiation-arena.html` — Negotiation Arena
+- `/privacy.html` — Privacy Policy
+- `/terms.html` — Terms of Service
+
+Authenticated flow (skipped unless `UAT_TEST_USER_EMAIL` + `UAT_TEST_USER_PASSWORD` are set):
+- Sign in via `/auth.html`, screenshot the post-login landing.
+
+## Adding a case
+
+Append a tuple to `PAGE_CASES` in `run_uat.py` for a simple
+load-and-assert-title case. For interactive flows (clicks, form fills),
+follow the `run_authenticated_flow` pattern — accept a `Page`, capture
+your own screenshots via `_shot(page, name)`, and return one or more
+`StepResult` objects.
+
+## Exit codes
+
+- `0` — every case passed (or skipped cleanly).
+- `1` — one or more cases failed. The `.pptx` is still written so
+  failures are visible in the report.
+- `2` — uncaught exception in the driver itself.

--- a/tests/uat/requirements.txt
+++ b/tests/uat/requirements.txt
@@ -1,0 +1,3 @@
+playwright==1.47.0
+python-pptx==1.0.2
+httpx==0.27.2

--- a/tests/uat/run_uat.py
+++ b/tests/uat/run_uat.py
@@ -1,0 +1,328 @@
+"""
+End-to-end UAT for the live LexAra deployment.
+
+Drives the production frontend with Playwright (Chromium), captures a
+screenshot per step, and emits a single .pptx report summarising pass /
+fail per case.
+
+Usage (locally or in CI):
+    pip install -r tests/uat/requirements.txt
+    playwright install --with-deps chromium
+    python tests/uat/run_uat.py
+
+Environment variables (all optional):
+    UAT_BASE_URL          default https://lexara.tech
+    UAT_API_BASE_URL      default https://api.lexara.tech
+    UAT_OUTPUT_DIR        default qa-reports/<UTC-timestamp>
+    UAT_TEST_USER_EMAIL   if set, runs the authenticated-flow case
+    UAT_TEST_USER_PASSWORD
+    UAT_HEADLESS          default 1; set 0 to watch the run locally
+
+Exit code 0 on full pass, 1 if any case fails. The .pptx is written
+regardless so failures are visible in the report.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import traceback
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+from playwright.sync_api import Browser, Page, sync_playwright
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("UAT_BASE_URL", "https://lexara.tech").rstrip("/")
+API_BASE_URL = os.environ.get("UAT_API_BASE_URL", "https://api.lexara.tech").rstrip("/")
+HEADLESS = os.environ.get("UAT_HEADLESS", "1") != "0"
+TEST_EMAIL = os.environ.get("UAT_TEST_USER_EMAIL")
+TEST_PASSWORD = os.environ.get("UAT_TEST_USER_PASSWORD")
+
+RUN_TIMESTAMP = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
+OUTPUT_DIR = Path(os.environ.get("UAT_OUTPUT_DIR", f"qa-reports/{RUN_TIMESTAMP}"))
+SCREENSHOT_DIR = OUTPUT_DIR / "screenshots"
+
+
+# ---------------------------------------------------------------------------
+# Test result model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StepResult:
+    name: str
+    status: str  # "pass" | "fail" | "skip"
+    detail: str = ""
+    screenshot: Path | None = None
+    duration_ms: int = 0
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _shot(page: Page, name: str) -> Path:
+    """Save a full-page screenshot. Returns its path."""
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    safe = name.lower().replace(" ", "_").replace("/", "_")
+    path = SCREENSHOT_DIR / f"{safe}.png"
+    page.screenshot(path=str(path), full_page=True)
+    return path
+
+
+def _verify_page(page: Page, url: str, title_substring: str, name: str) -> StepResult:
+    """Navigate, wait for load, assert title, screenshot."""
+    started = time.monotonic()
+    try:
+        page.goto(url, wait_until="networkidle", timeout=30_000)
+        actual = page.title()
+        shot = _shot(page, name)
+        if title_substring.lower() in actual.lower():
+            return StepResult(
+                name=name, status="pass",
+                detail=f"GET {url} | <title> contains '{title_substring}' (got '{actual}')",
+                screenshot=shot,
+                duration_ms=int((time.monotonic() - started) * 1000),
+            )
+        return StepResult(
+            name=name, status="fail",
+            detail=f"GET {url} | expected title to contain '{title_substring}', got '{actual}'",
+            screenshot=shot,
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+    except Exception as exc:
+        # Best-effort screenshot even on failure
+        try:
+            shot = _shot(page, f"{name}_error")
+        except Exception:
+            shot = None
+        return StepResult(
+            name=name, status="fail",
+            detail=f"Exception: {exc.__class__.__name__}: {exc}",
+            screenshot=shot,
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+
+
+def _api_check(path: str, expect_keys: list[str], name: str) -> StepResult:
+    """Hit an API endpoint and assert specific JSON keys are present."""
+    started = time.monotonic()
+    url = f"{API_BASE_URL}{path}"
+    try:
+        resp = httpx.get(url, timeout=15.0)
+        body = resp.json() if "application/json" in resp.headers.get("content-type", "") else {}
+        missing = [k for k in expect_keys if k not in body]
+        if resp.status_code == 200 and not missing:
+            preview = ", ".join(f"{k}={body[k]!r}" for k in expect_keys[:4])
+            return StepResult(
+                name=name, status="pass",
+                detail=f"GET {url} -> 200 | {preview}",
+                duration_ms=int((time.monotonic() - started) * 1000),
+            )
+        return StepResult(
+            name=name, status="fail",
+            detail=f"GET {url} -> {resp.status_code} | missing keys: {missing} | body={str(body)[:200]}",
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+    except Exception as exc:
+        return StepResult(
+            name=name, status="fail",
+            detail=f"Exception: {exc.__class__.__name__}: {exc}",
+            duration_ms=int((time.monotonic() - started) * 1000),
+        )
+
+
+# ---------------------------------------------------------------------------
+# UAT cases
+# ---------------------------------------------------------------------------
+
+PAGE_CASES: list[tuple[str, str, str]] = [
+    # (path, expected title substring, case name)
+    ("/", "LexAra", "Landing page"),
+    ("/auth.html", "Sign In", "Auth page"),
+    ("/procurement.html", "Procurement Tools", "Procurement Tools page"),
+    ("/procurement-ai.html", "Procurement AI", "Procurement AI page"),
+    ("/procurement-intelligence.html", "Procurement Intelligence", "Procurement Intelligence page"),
+    ("/negotiation-arena.html", "Negotiation Arena", "Negotiation Arena page"),
+    ("/privacy.html", "Privacy Policy", "Privacy page"),
+    ("/terms.html", "Terms of Service", "Terms page"),
+]
+
+
+def run_authenticated_flow(page: Page) -> list[StepResult]:
+    """Optional: log in and verify the authenticated landing renders."""
+    if not (TEST_EMAIL and TEST_PASSWORD):
+        return [StepResult(
+            name="Authenticated flow",
+            status="skip",
+            detail="UAT_TEST_USER_EMAIL / UAT_TEST_USER_PASSWORD not set — skipping",
+        )]
+
+    results: list[StepResult] = []
+    started = time.monotonic()
+    try:
+        page.goto(f"{BASE_URL}/auth.html", wait_until="networkidle", timeout=30_000)
+        # Selectors are pessimistic — we look for any input[type=email] / input[type=password].
+        page.fill("input[type=email]", TEST_EMAIL)
+        page.fill("input[type=password]", TEST_PASSWORD)
+        page.click("button[type=submit], input[type=submit]")
+        page.wait_for_load_state("networkidle", timeout=30_000)
+        shot = _shot(page, "post_login")
+        results.append(StepResult(
+            name="Authenticated flow — sign in",
+            status="pass" if "auth.html" not in page.url else "fail",
+            detail=f"after submit: url={page.url}",
+            screenshot=shot,
+            duration_ms=int((time.monotonic() - started) * 1000),
+        ))
+    except Exception as exc:
+        try:
+            shot = _shot(page, "auth_flow_error")
+        except Exception:
+            shot = None
+        results.append(StepResult(
+            name="Authenticated flow — sign in",
+            status="fail",
+            detail=f"Exception: {exc.__class__.__name__}: {exc}",
+            screenshot=shot,
+            duration_ms=int((time.monotonic() - started) * 1000),
+        ))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Report (.pptx)
+# ---------------------------------------------------------------------------
+
+def write_pptx(results: list[StepResult], output_path: Path) -> None:
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+
+    blank = prs.slide_layouts[6]  # blank layout
+    title_layout = prs.slide_layouts[0]  # title slide
+
+    # ── Title slide ───────────────────────────────────────────────────────
+    s = prs.slides.add_slide(title_layout)
+    s.shapes.title.text = "LexAra — End-to-End UAT Report"
+    subtitle = s.placeholders[1]
+    passed = sum(1 for r in results if r.status == "pass")
+    failed = sum(1 for r in results if r.status == "fail")
+    skipped = sum(1 for r in results if r.status == "skip")
+    subtitle.text = (
+        f"Run: {RUN_TIMESTAMP}\n"
+        f"Target: {BASE_URL}  |  API: {API_BASE_URL}\n"
+        f"Pass: {passed}   Fail: {failed}   Skip: {skipped}"
+    )
+
+    # ── Summary slide ─────────────────────────────────────────────────────
+    s = prs.slides.add_slide(blank)
+    tbox = s.shapes.add_textbox(Inches(0.5), Inches(0.3), Inches(12), Inches(0.7))
+    tf = tbox.text_frame
+    tf.text = "Summary"
+    tf.paragraphs[0].runs[0].font.size = Pt(28)
+    tf.paragraphs[0].runs[0].font.bold = True
+
+    rows = len(results) + 1
+    table = s.shapes.add_table(rows, 4, Inches(0.5), Inches(1.2), Inches(12.3), Inches(5.8)).table
+    headers = ["#", "Case", "Status", "Detail"]
+    for i, h in enumerate(headers):
+        cell = table.cell(0, i)
+        cell.text = h
+        for run in cell.text_frame.paragraphs[0].runs:
+            run.font.bold = True
+            run.font.size = Pt(12)
+    for idx, r in enumerate(results, start=1):
+        table.cell(idx, 0).text = str(idx)
+        table.cell(idx, 1).text = r.name
+        table.cell(idx, 2).text = r.status.upper()
+        table.cell(idx, 3).text = r.detail[:200]
+        for col in range(4):
+            for run in table.cell(idx, col).text_frame.paragraphs[0].runs:
+                run.font.size = Pt(10)
+
+    # ── One slide per result ──────────────────────────────────────────────
+    for idx, r in enumerate(results, start=1):
+        s = prs.slides.add_slide(blank)
+        title = s.shapes.add_textbox(Inches(0.5), Inches(0.3), Inches(12), Inches(0.7))
+        tf = title.text_frame
+        tf.text = f"{idx}. {r.name}  —  {r.status.upper()}"
+        tf.paragraphs[0].runs[0].font.size = Pt(24)
+        tf.paragraphs[0].runs[0].font.bold = True
+
+        meta = s.shapes.add_textbox(Inches(0.5), Inches(1.0), Inches(12), Inches(0.5))
+        meta.text_frame.text = f"{r.detail}   |   {r.duration_ms} ms   |   {r.started_at}"
+        meta.text_frame.paragraphs[0].runs[0].font.size = Pt(11)
+
+        if r.screenshot and r.screenshot.exists():
+            s.shapes.add_picture(
+                str(r.screenshot),
+                Inches(0.5), Inches(1.7),
+                width=Inches(12.3),
+            )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    prs.save(str(output_path))
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    results: list[StepResult] = []
+
+    print(f"UAT run starting | base={BASE_URL} api={API_BASE_URL} headless={HEADLESS}")
+    print(f"Output dir: {OUTPUT_DIR.resolve()}")
+
+    # API health smoke (no browser needed)
+    results.append(_api_check("/health", ["status"], "API /health"))
+    results.append(_api_check("/status", ["status", "service", "version", "uptime_seconds"], "API /status"))
+
+    # Browser flows
+    with sync_playwright() as pw:
+        browser: Browser = pw.chromium.launch(headless=HEADLESS)
+        ctx = browser.new_context(viewport={"width": 1440, "height": 900})
+        page = ctx.new_page()
+
+        for path, expected_title, name in PAGE_CASES:
+            print(f"  [{name}] -> {BASE_URL}{path}")
+            results.append(_verify_page(page, f"{BASE_URL}{path}", expected_title, name))
+
+        results.extend(run_authenticated_flow(page))
+
+        ctx.close()
+        browser.close()
+
+    # Report
+    pptx_path = OUTPUT_DIR / f"Lexara_UAT_{RUN_TIMESTAMP}.pptx"
+    write_pptx(results, pptx_path)
+
+    # Console summary
+    print("\n=== UAT summary ===")
+    for r in results:
+        marker = {"pass": "PASS", "fail": "FAIL", "skip": "SKIP"}[r.status]
+        print(f"  [{marker}] {r.name} — {r.detail[:120]}")
+    print(f"\nReport: {pptx_path}")
+
+    failed = sum(1 for r in results if r.status == "fail")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        traceback.print_exc()
+        sys.exit(2)


### PR DESCRIPTION
## Summary
Adds a repeatable end-to-end UAT pipeline that runs against the **live** LexAra deployment, captures a screenshot per step, and produces a `.pptx` report uploaded as a workflow artifact.

### What ships
- **`tests/uat/run_uat.py`** — Playwright (Chromium) driver. Smoke-tests `/health` and `/status` without a browser, then visits every public page on `lexara.tech`, asserts `<title>`, and full-page-screenshots. Optionally runs an authenticated flow if `UAT_TEST_USER_EMAIL` + `UAT_TEST_USER_PASSWORD` are set; skips cleanly otherwise.
- **`tests/uat/requirements.txt`** — pinned `playwright==1.47.0`, `python-pptx==1.0.2`, `httpx==0.27.2`.
- **`.github/workflows/uat.yml`** — triggers nightly at 03:00 UTC and on `workflow_dispatch` (with overrideable base URLs). Uploads the full `qa-reports/<run>` directory as artifact, retained 30 days. Job exit code follows the driver, so a red run is obvious in the Actions UI.
- **`tests/uat/README.md`** — local run instructions, env vars, current cases, how to extend.

### Cases covered (v1)
| Layer | Case |
|---|---|
| API | `GET /health` returns 200 + `status` field |
| API | `GET /status` returns 200 + `service`, `version`, `uptime_seconds` |
| Frontend | `/` Landing — title contains "LexAra" |
| Frontend | `/auth.html` — title "Sign In" |
| Frontend | `/procurement.html` — title "Procurement Tools" |
| Frontend | `/procurement-ai.html` — title "Procurement AI" |
| Frontend | `/procurement-intelligence.html` — title "Procurement Intelligence" |
| Frontend | `/negotiation-arena.html` — title "Negotiation Arena" |
| Frontend | `/privacy.html` / `/terms.html` |
| Auth flow | Sign in via `/auth.html` (skipped without secrets) |

### .pptx layout
1. Title slide — run timestamp, target URLs, pass/fail/skip counts.
2. Summary slide — tabular case list with status + detail.
3. One slide per case — screenshot + detail + duration + start time.

### Setup notes
**No new repo secrets are required for the basic suite.** To enable the authenticated-flow case, add two repo secrets:
- `UAT_TEST_USER_EMAIL`
- `UAT_TEST_USER_PASSWORD`

Use a dedicated test account on a non-billing plan — the suite logs in fully and screenshots whatever lands.

### Test plan
- [x] `python -m py_compile` clean on the driver
- [x] `yaml.safe_load` clean on the workflow
- [ ] First nightly run produces a `.pptx` artifact
- [ ] Manual `workflow_dispatch` run with custom base URLs works
- [ ] All 8 page cases pass (titles match what's currently in `website/*.html`)
- [ ] Authenticated case skips with a clean `SKIP` row when secrets are absent

### Deliberately not in v1
- No interactive form submissions beyond login (e.g. SOW Workbench, Negotiation Arena UI flows) — needs stable selectors which I haven't audited yet.
- No visual-diff regression (Percy / Argos). Adding later is a one-line dependency swap.
- No mobile viewport runs — easy to add by parameterising `viewport=` in `run_uat.py`.
- No PDF / HTML report — the user asked for .pptx specifically.

https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC)_