### PR TITLE
fix(deploy): wait for container HEALTHCHECK instead of sleep 6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,12 +83,28 @@ jobs:
             docker compose up -d api
             docker image prune -f
 
-            # Smoke test the new container against /status. Fall back to
-            # public Traefik route after a short warm-up to also exercise TLS.
-            sleep 6
+            # Wait for the new container to report healthy (per the Dockerfile
+            # HEALTHCHECK that probes /status). Times out after ~150s to cover
+            # FAISS bootstrap + clause seed on a cold start.
+            echo "Waiting for api to become healthy..."
+            for i in $(seq 1 15); do
+              state=$(docker inspect --format '{{.State.Health.Status}}' lexara-api-api-1 2>/dev/null || echo "unknown")
+              if [ "$state" = "healthy" ]; then
+                echo "api is healthy after ${i} attempts"
+                break
+              fi
+              if [ "$i" -eq 15 ]; then
+                echo "api never became healthy (last state: $state) — dumping logs:"
+                docker compose logs --tail=100 api
+                exit 1
+              fi
+              sleep 10
+            done
+
+            # End-to-end check through Traefik / TLS.
             if ! curl -fsS --max-time 10 https://api.lexara.tech/status; then
-              echo "Smoke test failed — dumping last 100 lines of api logs:"
-              docker compose logs --tail=100 api
+              echo "Container is healthy but public endpoint failed — Traefik routing issue?"
+              docker compose logs --tail=50 api
               exit 1
             fi
             echo

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Install runtime tools used for healthchecks and ad-hoc debugging from
+# inside the container (the slim base image ships neither).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 COPY requirements.txt .
 # CA-021: model is downloaded from HuggingFace Hub at build time.
@@ -18,5 +24,10 @@ RUN pip install --no-cache-dir -r requirements.txt && \
 COPY . .
 
 EXPOSE 8000
+
+# Marks the container "healthy" only once /status answers 200. Long
+# start_period covers FAISS bootstrap + clause seed on first boot.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=90s --retries=3 \
+    CMD curl -fsS http://localhost:8000/status > /dev/null || exit 1
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,11 +23,30 @@ docker compose pull api
 docker compose up -d api
 docker image prune -f
 
-sleep 6
+# Wait for the new container to become healthy. The HEALTHCHECK in the
+# Dockerfile probes /status; we poll docker for its result rather than
+# guessing a sleep duration. Times out after ~150s (10s * 15 attempts) to
+# cover FAISS bootstrap + clause seed on a cold start.
+echo "Waiting for api to become healthy..."
+for i in $(seq 1 15); do
+  state=$(docker inspect --format '{{.State.Health.Status}}' lexara-api-api-1 2>/dev/null || echo "unknown")
+  if [ "$state" = "healthy" ]; then
+    echo "api is healthy after ${i} attempts"
+    break
+  fi
+  if [ "$i" -eq 15 ]; then
+    echo "api never became healthy (last state: $state) — last 100 lines of logs:"
+    docker compose logs --tail=100 api
+    exit 1
+  fi
+  sleep 10
+done
+
+# End-to-end check through Traefik / TLS.
 if curl -fsS --max-time 10 https://api.lexara.tech/status > /dev/null; then
   echo "Deploy of $API_TAG OK"
 else
-  echo "Smoke test failed — last 100 lines of api logs:"
-  docker compose logs --tail=100 api
+  echo "Container is healthy but public endpoint failed — Traefik routing issue?"
+  docker compose logs --tail=50 api
   exit 1
 fi


### PR DESCRIPTION
## Summary
Fixes the timing bug that caused PR #20's first real deploy to report a 502 on its smoke test even though the container ultimately came up healthy. Replaces `sleep 6` with a real wait-for-ready loop driven by Docker's HEALTHCHECK — the next deploy won't false-fail on a cold start.

### What broke last time
The api lifespan does FAISS bootstrap + clause seeding on first boot, which takes ~30–60 s. The deploy workflow's `sleep 6 && curl …/status` ran before the app finished startup, got a 502 from Traefik, and dumped logs that showed only `INFO: Waiting for application startup.` — confusing because nothing was actually wrong.

### What changes
- **`Dockerfile`**:
  - Install `curl` in the runtime image (the `python:3.11-slim` base ships neither `curl` nor `wget`, which is why your earlier `docker compose exec api curl …` failed).
  - Add `HEALTHCHECK` against `/status` with `start_period=90s`, `interval=15s`, `retries=3`. Container only reports `healthy` once `/status` actually answers 200.
- **`.github/workflows/deploy.yml`**: replace `sleep 6 && curl` with a poll loop that reads `docker inspect ... .State.Health.Status` until the container reports healthy (max ~150s). Then a *separate* end-to-end curl through Traefik — so a future failure tells you whether it's the app (unhealthy) or routing (healthy + 502).
- **`scripts/deploy.sh`**: same wait-for-healthy + separate Traefik probe.

### Side benefits
- `docker compose ps` now shows `(healthy)` / `(unhealthy)` status for the api service — easier ops.
- Traefik's existing `healthcheck.path=/status` label (added in PR #20) now has a backend-side counterpart, so unhealthy containers are evicted from the LB pool faster.
- `docker compose exec api curl …` will work for ad-hoc debugging.

## Test plan
- [x] `bash -n scripts/deploy.sh` clean
- [x] `yaml.safe_load` clean on `deploy.yml`
- [ ] Next push to `main`: workflow waits up to ~150s for `healthy`, smoke test passes
- [ ] `docker compose ps api` reports `Up X seconds (healthy)` after a deploy
- [ ] Forced unhealthy container (e.g. break `DATABASE_URL`) trips the workflow at the wait-for-healthy step instead of the public-curl step

https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWcDty55M9qhx3CzUvzkaC)_